### PR TITLE
Wrong image name

### DIFF
--- a/app/code/Turiknox/SampleImageUploader/Ui/DataProvider/Image/Form/Modifier/ImageData.php
+++ b/app/code/Turiknox/SampleImageUploader/Ui/DataProvider/Image/Form/Modifier/ImageData.php
@@ -49,9 +49,9 @@ class ImageData implements ModifierInterface
         /** @var $image \Turiknox\SampleImageUploader\Model\Image */
         foreach ($items as $image) {
             $_data = $image->getData();
-            if (isset($_data['image'])) {
+            if (isset($_data['image']) && $_data['image'] != '') {
                 $imageArr = [];
-                $imageArr[0]['name'] = 'Image';
+                $imageArr[0]['name'] = $image->getImage();
                 $imageArr[0]['url'] = $image->getImageUrl();
                 $_data['image'] = $imageArr;
             }


### PR DESCRIPTION
If the picture exists and we press the "Save" button, the picture will be lost due to an incorrect name.